### PR TITLE
Update Readme with two datasets named LINZ and UGRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Vehicle Detection in Aerial Imagery. Bounding box annotations
 * [pytorch-vedai](https://github.com/MichelHalmes/pytorch-vedai)
 
 ## Cars Overhead With Context (COWC)
-Large set of annotated cars from overhead. Established baseline for object detection and counting tasks. Annotations in bounding box formatr
+Large set of annotated cars from overhead. Established baseline for object detection and counting tasks. Annotations in bounding box format
 * http://gdo152.ucllnl.org/cowc/
 * https://github.com/LLNL/cowc
 * [Detecting cars from aerial imagery for the NATO Innovation Challenge](https://arthurdouillard.com/post/nato-challenge/)

--- a/README.md
+++ b/README.md
@@ -285,10 +285,11 @@ Vehicle Detection in Aerial Imagery. Bounding box annotations
 * [pytorch-vedai](https://github.com/MichelHalmes/pytorch-vedai)
 
 ## Cars Overhead With Context (COWC)
-Large set of annotated cars from overhead. Established baseline for object detection and counting tasks. Annotations in bounding box format
+Large set of annotated cars from overhead. Established baseline for object detection and counting tasks. Annotations in bounding box formatr
 * http://gdo152.ucllnl.org/cowc/
 * https://github.com/LLNL/cowc
 * [Detecting cars from aerial imagery for the NATO Innovation Challenge](https://arthurdouillard.com/post/nato-challenge/)
+* [LINZ and UGRC](https://github.com/humansensinglab/AGenDA/tree/main/Data)
 
 ## AI-TOD & AI-TOD-v2 - tiny object detection
 The mean size of objects in AI-TOD is about 12.8 pixels, which is much smaller than other datasets. Annotations in bounding box format. V2 is a meticulous relabelling of the v1 dataset


### PR DESCRIPTION
Hi Robin, I create a pull request to contribute two [(bbox annotated datasets)](https://github.com/humansensinglab/AGenDA/tree/main/Data) that are part of the contribution of this ICCV paper on aerial imagery [(http://arxiv.org/abs/2507.20976)](http://arxiv.org/abs/2507.20976) to this repo.
The two datasets are collected from New Zealand and Utah, which are used for small vehicle (mostly car) detection in aerial imagery.
Thanks.